### PR TITLE
Don't try to modify frozen template

### DIFF
--- a/lib/markdown_views/renderer.rb
+++ b/lib/markdown_views/renderer.rb
@@ -4,9 +4,9 @@ module MarkdownViews
 
       def render(template)
         out = template.to_s
-        strip_comments!(out) if MarkdownViews.strip_comments
+        out = strip_comments(out) if MarkdownViews.strip_comments
         out = render_md(out)
-        strip_comments!(out) if MarkdownViews.strip_comments
+        out = strip_comments(out) if MarkdownViews.strip_comments
         out.html_safe
       end
 
@@ -24,8 +24,8 @@ module MarkdownViews
         MarkdownViews.rouge_opts[:formatter] || Rouge::Formatters::HTML.new
       end
 
-      def strip_comments!(input)
-        input.gsub!(/[ \t\r\n\f]*<!--(.*?)-->*/m, '')
+      def strip_comments(input)
+        input.gsub(/[ \t\r\n\f]*<!--(.*?)-->*/m, '')
       end
 
       def transform_code_blocks(doc)


### PR DESCRIPTION
Ruby 2.7 change the behavior of `NilClass.to_s`. It now returns a frozen string.

When the template is `nil` we get a frozen string that we can't modify with `gsub!`. When we try to modify it we get `Error:  can't modify frozen String: ""`

The solution is to use `gsub` instead of `gsub!`